### PR TITLE
Adding :admin:tools:install task to travis build

### DIFF
--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -48,7 +48,8 @@ TERM=dumb ./gradlew \
 :common:scala:install \
 :core:controller:install \
 :core:invoker:install \
-:tests:install
+:tests:install \
+:tools:admin:install
 
 # Build runtime
 cd $ROOTDIR


### PR DESCRIPTION
This PR fixes the travis build failure reported in issue https://github.com/apache/incubator-openwhisk-runtime-swift/issues/68