### PR TITLE
remove the pre-optimize latest images

### DIFF
--- a/core/swift42Action/Dockerfile
+++ b/core/swift42Action/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM openwhisk/actionloop as builder
+FROM openwhisk/actionloop:nightly as builder
 
 FROM swift:4.2
 
@@ -39,9 +39,9 @@ COPY Package.swift /swiftAction/
 COPY buildandrecord.py /swiftAction/
 COPY main.swift /swiftAction/Sources/
 RUN swift build -c release; \
-touch /swiftAction/Sources/main.swift; \
-rm /swiftAction/.build/release/Action; \
-/swiftAction/buildandrecord.py
+	touch /swiftAction/Sources/main.swift; \
+	rm /swiftAction/.build/release/Action; \
+	/swiftAction/buildandrecord.py
 
 
 ENV OW_COMPILER=/bin/compile

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -37,12 +37,12 @@ scancode/scanCode.py --config scancode/ASF-Release.cfg $ROOTDIR
 cd $WHISKDIR
 
 #pull down images
-docker pull openwhisk/controller
-docker tag openwhisk/controller ${IMAGE_PREFIX}/controller
-docker pull openwhisk/invoker
-docker tag openwhisk/invoker ${IMAGE_PREFIX}/invoker
-docker pull openwhisk/nodejs6action
-docker tag openwhisk/nodejs6action nodejs6action
+docker pull openwhisk/controller:nightly
+docker tag openwhisk/controller:nightly ${IMAGE_PREFIX}/controller
+docker pull openwhisk/invoker:nightly
+docker tag openwhisk/invoker:nightly ${IMAGE_PREFIX}/invoker
+docker pull openwhisk/nodejs6action:nightly
+docker tag openwhisk/nodejs6action:nightly nodejs6action
 
 TERM=dumb ./gradlew install
 


### PR DESCRIPTION
The removal of `latest` images from docker hub broke the travis pipeline